### PR TITLE
Fixing mistyped word "Addicionar" to "Adicionar"

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,7 +79,7 @@
                     <p><button class="btn btn-primary btn-large addmarker">
                       <i class="icon-map-marker icon-white">
                       </i>
-                      Addicionar ponto
+                      Adicionar ponto
                     </button></p>
                     <div id="listmarkers"></div>
                     <div id="linelistsidebar" class="lineListSidebar">


### PR DESCRIPTION
Fixing mistyped word "Addicionar" to "Adicionar", which is the correct spelling in pt-br
